### PR TITLE
Implement mentionable select and clear permissions button

### DIFF
--- a/roomer/roomer.py
+++ b/roomer/roomer.py
@@ -539,8 +539,11 @@ class ChannelControlView(discord.ui.View):
         if not await self._check_permissions(interaction):
             return
 
+        category = self.channel.category
+        new_overwrites = category.overwrites if category else {}
+
         try:
-            await self.channel.edit(overwrites={})
+            await self.channel.edit(overwrites=new_overwrites)
             await interaction.response.send_message(
                 "✅ All permission overwrites have been cleared.", ephemeral=True
             )

--- a/roomer/roomer.py
+++ b/roomer/roomer.py
@@ -301,7 +301,8 @@ class MentionableSelect(discord.ui.MentionableSelect):
         if mentions:
             action_text = "permitted" if self.action == "permit" else "forbidden"
             await interaction.response.send_message(
-                f"✅ Updated permissions for: {', '.join(mentions)} ({action_text}).", ephemeral=True
+                f"✅ Updated permissions for: {', '.join(mentions)} ({action_text}).",
+                ephemeral=True,
             )
         else:
             await interaction.response.send_message(

--- a/roomer/roomer.py
+++ b/roomer/roomer.py
@@ -281,27 +281,32 @@ class MentionableSelect(discord.ui.MentionableSelect):
         super().__init__(placeholder="Select a user or role...", min_values=1, max_values=25)
 
     async def callback(self, interaction: discord.Interaction):
-        selected = self.values[0]
-        target = None
+        mentions = []
+        for selected in self.values:
+            target = None
 
-        if isinstance(selected, discord.Member):
-            target = selected
-        elif isinstance(selected, discord.Role):
-            target = selected
+            if isinstance(selected, discord.Member):
+                target = selected
+            elif isinstance(selected, discord.Role):
+                target = selected
 
-        if target:
-            if self.action == "permit":
-                await self.channel.set_permissions(target, connect=True, view_channel=True)
-                await interaction.response.send_message(
-                    f"✅ {target.mention} has been permitted.", ephemeral=True
-                )
-            elif self.action == "forbid":
-                await self.channel.set_permissions(target, connect=False)
-                await interaction.response.send_message(
-                    f"✅ {target.mention} has been forbidden.", ephemeral=True
-                )
+            if target:
+                if self.action == "permit":
+                    await self.channel.set_permissions(target, connect=True, view_channel=True)
+                    mentions.append(target.mention)
+                elif self.action == "forbid":
+                    await self.channel.set_permissions(target, connect=False)
+                    mentions.append(target.mention)
+
+        if mentions:
+            action_text = "permitted" if self.action == "permit" else "forbidden"
+            await interaction.response.send_message(
+                f"✅ Updated permissions for: {', '.join(mentions)} ({action_text}).", ephemeral=True
+            )
         else:
-            await interaction.response.send_message("❌ Invalid selection.", ephemeral=True)
+            await interaction.response.send_message(
+                "❌ No valid users or roles were selected.", ephemeral=True
+            )
 
 
 class MentionableView(discord.ui.View):

--- a/roomer/roomer.py
+++ b/roomer/roomer.py
@@ -534,6 +534,7 @@ class ChannelControlView(discord.ui.View):
         await interaction.response.edit_message(view=self)
         await interaction.followup.send("🔄 Channel reset to default settings.", ephemeral=True)
 
+
 @discord.ui.button(label="🧹 Clear Permissions", row=3, style=discord.ButtonStyle.secondary)
 async def clear_permissions(self, interaction: discord.Interaction, button: discord.ui.Button):
     if not await self._check_permissions(interaction):

--- a/roomer/roomer.py
+++ b/roomer/roomer.py
@@ -277,11 +277,11 @@ class SetStatusModal(discord.ui.Modal, title="Set Channel Status"):
 class MentionableSelect(discord.ui.MentionableSelect):
     def __init__(self, channel: discord.VoiceChannel, action: str):
         self.channel = channel
-        self.action = action  # "permit" or "forbid"
-        super().__init__(placeholder="Select a user or role...", min_values=1, max_values=1)
+        self.action = action
+        super().__init__(placeholder="Select a user or role...", min_values=1, max_values=25)
 
     async def callback(self, interaction: discord.Interaction):
-        selected = self.values[0]  # The selected mentionable (user or role)
+        selected = self.values[0]
         target = None
 
         if isinstance(selected, discord.Member):
@@ -291,13 +291,11 @@ class MentionableSelect(discord.ui.MentionableSelect):
 
         if target:
             if self.action == "permit":
-                # Permit logic: Set connect=True and view_channel=True
                 await self.channel.set_permissions(target, connect=True, view_channel=True)
                 await interaction.response.send_message(
                     f"✅ {target.mention} has been permitted.", ephemeral=True
                 )
             elif self.action == "forbid":
-                # Forbid logic: Set connect=False
                 await self.channel.set_permissions(target, connect=False)
                 await interaction.response.send_message(
                     f"✅ {target.mention} has been forbidden.", ephemeral=True

--- a/roomer/roomer.py
+++ b/roomer/roomer.py
@@ -534,20 +534,20 @@ class ChannelControlView(discord.ui.View):
         await interaction.response.edit_message(view=self)
         await interaction.followup.send("🔄 Channel reset to default settings.", ephemeral=True)
 
-@discord.ui.button(label="🧹 Clear Permissions", row=3, style=discord.ButtonStyle.secondary)
-async def clear_permissions(self, interaction: discord.Interaction, button: discord.ui.Button):
-    if not await self._check_permissions(interaction):
-        return
+    @discord.ui.button(label="🧹 Clear Permissions", row=3, style=discord.ButtonStyle.secondary)
+    async def clear_permissions(self, interaction: discord.Interaction, button: discord.ui.Button):
+        if not await self._check_permissions(interaction):
+            return
 
-    try:
-        await self.channel.edit(overwrites={})
-        await interaction.response.send_message(
-            "✅ All permission overwrites have been cleared.", ephemeral=True
-        )
-    except Exception as e:
-        await interaction.response.send_message(
-            f"❌ Failed to clear permissions: {e}", ephemeral=True
-        )
+        try:
+            await self.channel.edit(overwrites={})
+            await interaction.response.send_message(
+                "✅ All permission overwrites have been cleared.", ephemeral=True
+            )
+        except Exception as e:
+            await interaction.response.send_message(
+                f"❌ Failed to clear permissions: {e}", ephemeral=True
+            )
 
     @discord.ui.button(label="🎙 Claim Room", row=4, style=discord.ButtonStyle.secondary)
     async def claim(self, interaction: discord.Interaction, button: discord.ui.Button):

--- a/roomer/roomer.py
+++ b/roomer/roomer.py
@@ -305,10 +305,12 @@ class MentionableSelect(discord.ui.MentionableSelect):
         else:
             await interaction.response.send_message("❌ Invalid selection.", ephemeral=True)
 
+
 class MentionableView(discord.ui.View):
     def __init__(self, channel: discord.VoiceChannel, action: str):
         super().__init__()
         self.add_item(MentionableSelect(channel, action))
+
 
 class RenameModal(discord.ui.Modal, title="Rename Voice Channel"):
     name = discord.ui.TextInput(
@@ -468,18 +470,17 @@ class ChannelControlView(discord.ui.View):
     async def permit(self, interaction: discord.Interaction, button: discord.ui.Button):
         if not await self._check_permissions(interaction):
             return
-    
+
         view = MentionableView(self.channel, action="permit")
         await interaction.response.send_message(
             "Select a user or role to permit:", view=view, ephemeral=True
         )
-    
-    
+
     @discord.ui.button(label="➖ Forbid", row=1, style=discord.ButtonStyle.danger)
     async def forbid(self, interaction: discord.Interaction, button: discord.ui.Button):
         if not await self._check_permissions(interaction):
             return
-    
+
         view = MentionableView(self.channel, action="forbid")
         await interaction.response.send_message(
             "Select a user or role to forbid:", view=view, ephemeral=True

--- a/roomer/roomer.py
+++ b/roomer/roomer.py
@@ -533,7 +533,22 @@ class ChannelControlView(discord.ui.View):
         await interaction.response.edit_message(view=self)
         await interaction.followup.send("🔄 Channel reset to default settings.", ephemeral=True)
 
-    @discord.ui.button(label="🎙 Claim Room", row=3, style=discord.ButtonStyle.secondary)
+@discord.ui.button(label="🧹 Clear Permissions", row=3, style=discord.ButtonStyle.secondary)
+async def clear_permissions(self, interaction: discord.Interaction, button: discord.ui.Button):
+    if not await self._check_permissions(interaction):
+        return
+
+    try:
+        await self.channel.edit(overwrites={})
+        await interaction.response.send_message(
+            "✅ All permission overwrites have been cleared.", ephemeral=True
+        )
+    except Exception as e:
+        await interaction.response.send_message(
+            f"❌ Failed to clear permissions: {e}", ephemeral=True
+        )
+
+    @discord.ui.button(label="🎙 Claim Room", row=4, style=discord.ButtonStyle.secondary)
     async def claim(self, interaction: discord.Interaction, button: discord.ui.Button):
         try:
             cog = self.cog


### PR DESCRIPTION
- To avoid issues with large amounts of users, now mentionable selections are available for permit / forbid actions
- A clear permissions button has been added to only clear the overwrites without resetting the channel title/status/limit/etc.