### PR TITLE
Add permission overwrites for channel owners

### DIFF
--- a/roomer/roomer.py
+++ b/roomer/roomer.py
@@ -277,18 +277,20 @@ class SetStatusModal(discord.ui.Modal, title="Set Channel Status"):
 
 
 class MentionableSelect(discord.ui.MentionableSelect):
-    def __init__(self, channel: discord.VoiceChannel, action: str):
+    def __init__(self, channel: discord.VoiceChannel, action: str, channel_owners: dict):
         self.channel = channel
         self.action = action
+        self.channel_owners = channel_owners
         super().__init__(placeholder="Select a user or role...", min_values=1, max_values=25)
 
     async def callback(self, interaction: discord.Interaction):
         mentions = []
+        current_owner = self.channel_owners.get(self.channel.id)
         for selected in self.values:
             target = None
 
             if isinstance(selected, discord.Member):
-                if self.channel_owners.get(self.channel.id) == selected.id:
+                if current_owner == selected.id:
                     await interaction.response.send_message(
                         "❌ You cannot modify your own permissions.", ephemeral=True
                     )

--- a/roomer/roomer.py
+++ b/roomer/roomer.py
@@ -487,7 +487,7 @@ class ChannelControlView(discord.ui.View):
         if not await self._check_permissions(interaction):
             return
 
-        view = MentionableView(self.channel, action="permit")
+        view = MentionableView(self.channel, action="permit", channel_owners=self.cog.channel_owners)
         await interaction.response.send_message(
             "Select a user or role to permit:", view=view, ephemeral=True
         )
@@ -497,7 +497,7 @@ class ChannelControlView(discord.ui.View):
         if not await self._check_permissions(interaction):
             return
 
-        view = MentionableView(self.channel, action="forbid")
+        view = MentionableView(self.channel, action="forbid", channel_owners=self.cog.channel_owners)
         await interaction.response.send_message(
             "Select a user or role to forbid:", view=view, ephemeral=True
         )

--- a/roomer/roomer.py
+++ b/roomer/roomer.py
@@ -220,7 +220,6 @@ class Roomer(red_commands.Cog):
             return
 
         overwrites = after.channel.overwrites
-        overwrites[member] = discord.PermissionOverwrite(connect=True, view_channel=True)
 
         category = after.channel.category
         new_channel = await category.create_voice_channel(
@@ -230,7 +229,9 @@ class Roomer(red_commands.Cog):
             reason="Auto voice channel creation",
         )
         await member.move_to(new_channel, reason="Moved to new voice room")
-
+        await new_channel.set_permissions(
+            member, view_channel=True, connect=True
+        )
         self.channel_owners[new_channel.id] = member.id
 
         try:

--- a/roomer/roomer.py
+++ b/roomer/roomer.py
@@ -487,7 +487,9 @@ class ChannelControlView(discord.ui.View):
         if not await self._check_permissions(interaction):
             return
 
-        view = MentionableView(self.channel, action="permit", channel_owners=self.cog.channel_owners)
+        view = MentionableView(
+            self.channel, action="permit", channel_owners=self.cog.channel_owners
+        )
         await interaction.response.send_message(
             "Select a user or role to permit:", view=view, ephemeral=True
         )
@@ -497,7 +499,9 @@ class ChannelControlView(discord.ui.View):
         if not await self._check_permissions(interaction):
             return
 
-        view = MentionableView(self.channel, action="forbid", channel_owners=self.cog.channel_owners)
+        view = MentionableView(
+            self.channel, action="forbid", channel_owners=self.cog.channel_owners
+        )
         await interaction.response.send_message(
             "Select a user or role to forbid:", view=view, ephemeral=True
         )

--- a/roomer/roomer.py
+++ b/roomer/roomer.py
@@ -229,9 +229,7 @@ class Roomer(red_commands.Cog):
             reason="Auto voice channel creation",
         )
         await member.move_to(new_channel, reason="Moved to new voice room")
-        await new_channel.set_permissions(
-            member, view_channel=True, connect=True
-        )
+        await new_channel.set_permissions(member, view_channel=True, connect=True)
         self.channel_owners[new_channel.id] = member.id
 
         try:

--- a/roomer/roomer.py
+++ b/roomer/roomer.py
@@ -321,9 +321,9 @@ class MentionableSelect(discord.ui.MentionableSelect):
 
 
 class MentionableView(discord.ui.View):
-    def __init__(self, channel: discord.VoiceChannel, action: str):
+    def __init__(self, channel: discord.VoiceChannel, action: str, channel_owners: dict):
         super().__init__()
-        self.add_item(MentionableSelect(channel, action))
+        self.add_item(MentionableSelect(channel, action, channel_owners))
 
 
 class RenameModal(discord.ui.Modal, title="Rename Voice Channel"):

--- a/roomer/roomer.py
+++ b/roomer/roomer.py
@@ -30,6 +30,7 @@ class Roomer(red_commands.Cog):
             presets={},
         )
         self.channel_owners = {}
+        self.reminder_messages = {}
 
     async def red_delete_data_for_user(self, **kwargs):
         return

--- a/roomer/roomer.py
+++ b/roomer/roomer.py
@@ -590,6 +590,10 @@ class ChannelControlView(discord.ui.View):
 
             current_owner = self.channel.guild.get_member(current_owner_id)
             if not current_owner or current_owner not in self.channel.members:
+                await self.channel.set_permissions(current_owner, overwrite=None)
+                await self.channel.set_permissions(
+                    interaction.user, view_channel=True, connect=True
+                )
                 self.owner_id = interaction.user.id
                 cog.channel_owners[self.channel.id] = interaction.user.id
                 await interaction.response.send_message(


### PR DESCRIPTION
Fixed permission overwrites for channel owners when using hide/lock/claim. Makes it so that the channel owner always has view_channel and connect permissions set to True, and also cannot change their own permissions to avoid mistakes.